### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/Release-DockerHub.yaml
+++ b/.github/workflows/Release-DockerHub.yaml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@master
 
       - name: Publish to DockerHub
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: grolimundachim/aws_scheduler
           username: ${{ secrets.DOCKER_USERNAME }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore